### PR TITLE
fix bufnr

### DIFF
--- a/plugin/qfpopup.vim
+++ b/plugin/qfpopup.vim
@@ -31,7 +31,7 @@ function! s:popup_error_under_cursor() abort
   if getcmdwintype() ==# ''
     call s:popup_clear()
   endif
-  let error = s:get_error_by_pos(getpos('.'), win_getid())
+  let error = s:get_error_by_pos(bufnr('%'), line('.'), win_getid())
   " Skip if current line is same as `error.text`
   " because it's useless (no additional information).
   " e.g.) the quickfix of `:grep`
@@ -51,11 +51,10 @@ endfunction
 
 " TODO use {what} argument
 " TODO filter by more accurate pos
-function! s:get_error_by_pos(pos, winid) abort
-  let [bufnr, lnum] = a:pos[0:1]
+function! s:get_error_by_pos(bufnr, lnum, winid) abort
   let loclist = getloclist(a:winid)
   let qflist = getqflist()
-  let l:F = { _,error -> error.bufnr is bufnr && error.lnum is lnum }
+  let l:F = { _,error -> error.bufnr is a:bufnr && error.lnum is a:lnum }
   call filter(loclist, l:F)
   call filter(qflist, l:F)
   return !empty(loclist) ? loclist[0] :


### PR DESCRIPTION
`bufnr` in `s:get_error_by_pos` is always 0 because `getpos` returns 0 as `bufnr` unless `getpos` takes a mark like `'A` as the argument.
To get a correct `bufnr`, `getpos('.')` was replaced by `bufnr('%')` and `line('.')`.